### PR TITLE
Fix: Readme example is throwing an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Lighthouse::url('https://example.com')
 Here's how you can get the results of an audit:
 
 ```php
-$result->audit('First Contentful Paint') // returns this array
+$result->audit('first-contentful-paint') // returns this array
 
 /*
  * [


### PR DESCRIPTION
@freekmurze 

Maybe it'll be better to expose constants so users won't have that kind of issue?
Or maybe a non-formatted method?

```PHP
$result->firstContentfulPaint()
```