### PR TITLE
New: Add `Lighthouse::gather()` & `Lighthouse::audit()` methods

### DIFF
--- a/bin/lighthouse.js
+++ b/bin/lighthouse.js
@@ -25,5 +25,5 @@ const chromeLauncher = require('chrome-launcher');
 
     await chrome.kill();
 
-    process.stdout.write(JSON.stringify(runnerResult));
+    process.stdout.write(JSON.stringify(runnerResult ?? {}));
 })();

--- a/bin/lighthouse.js
+++ b/bin/lighthouse.js
@@ -25,5 +25,5 @@ const chromeLauncher = require('chrome-launcher');
 
     await chrome.kill();
 
-    process.stdout.write(JSON.stringify(runnerResult ?? {}));
+    process.stdout.write(JSON.stringify(runnerResult));
 })();

--- a/docs/usage/configuring-a-run.md
+++ b/docs/usage/configuring-a-run.md
@@ -120,6 +120,32 @@ $result = Lighthouse::url('https://example.com')
 
 Optionally, you can pass a `cpuSlowdownMultiplier` as an int to `throttleCpu()`. The higher the number, the more throttling is applied. You'll find more information on this number [in the lighthouse docs](https://github.com/GoogleChrome/lighthouse/blob/main/docs/throttling.md#cpu-throttling).
 
+## Save artifacts to disk
+
+By default, Lighthouse will not save the artifacts to disk. To enable this, use the `gather()` method.
+
+
+```php
+use Spatie\Lighthouse\Lighthouse;
+
+$result = Lighthouse::url('https://example.com')
+    ->gather(__DIR__.'/path/to/artifacts/dir')
+    ->run();
+```
+
+## Process saved artifacts
+
+If you have saved artifacts from a previous run, you can process them using `audit()`.
+
+
+```php
+use Spatie\Lighthouse\Lighthouse;
+
+$result = Lighthouse::url('https://example.com')
+    ->audit(__DIR__.'/path/to/artifacts/dir')
+    ->run();
+```
+
 ## Customize the Lighthouse configuration
 
 To have fine-grained control of which options will be sent to lighthouse, you can pass an array of options to  `withConfig`.

--- a/docs/usage/configuring-a-run.md
+++ b/docs/usage/configuring-a-run.md
@@ -120,29 +120,16 @@ $result = Lighthouse::url('https://example.com')
 
 Optionally, you can pass a `cpuSlowdownMultiplier` as an int to `throttleCpu()`. The higher the number, the more throttling is applied. You'll find more information on this number [in the lighthouse docs](https://github.com/GoogleChrome/lighthouse/blob/main/docs/throttling.md#cpu-throttling).
 
-## Save artifacts to disk
+## Store artifacts to disk
 
-By default, Lighthouse will not save the artifacts to disk. To enable this, use the `gather()` method.
-
-
-```php
-use Spatie\Lighthouse\Lighthouse;
-
-$result = Lighthouse::url('https://example.com')
-    ->gather(__DIR__.'/path/to/artifacts/dir')
-    ->run();
-```
-
-## Process saved artifacts
-
-If you have saved artifacts from a previous run, you can process them using `audit()`.
+By default, Lighthouse will not save the artifacts to disk. To enable this, use the `storeArtifactsInDirectory()` method.
 
 
 ```php
 use Spatie\Lighthouse\Lighthouse;
 
 $result = Lighthouse::url('https://example.com')
-    ->audit(__DIR__.'/path/to/artifacts/dir')
+    ->storeArtifactsInDirectory(__DIR__.'/path/to/artifacts/dir')
     ->run();
 ```
 

--- a/src/Lighthouse.php
+++ b/src/Lighthouse.php
@@ -172,6 +172,20 @@ class Lighthouse
         return $this;
     }
 
+    public function gather($artifactsDir = ''): self
+    {
+        Arr::set($this->lighthouseConfig, 'settings.gatherMode', $artifactsDir);
+
+        return $this;
+    }
+
+    public function audit($artifactsDir = ''): self
+    {
+        Arr::set($this->lighthouseConfig, 'settings.auditMode', $artifactsDir);
+
+        return $this;
+    }
+
     public function withConfig(array $lighthouseConfig): self
     {
         $this->lighthouseConfig = $lighthouseConfig;

--- a/src/Lighthouse.php
+++ b/src/Lighthouse.php
@@ -172,16 +172,10 @@ class Lighthouse
         return $this;
     }
 
-    public function gather($artifactsDir = ''): self
+    public function storeArtifactsInDirectory(string $dir): self
     {
-        Arr::set($this->lighthouseConfig, 'settings.gatherMode', $artifactsDir);
-
-        return $this;
-    }
-
-    public function audit($artifactsDir = ''): self
-    {
-        Arr::set($this->lighthouseConfig, 'settings.auditMode', $artifactsDir);
+        Arr::set($this->lighthouseConfig, 'settings.gatherMode', $dir);
+        Arr::set($this->lighthouseConfig, 'settings.auditMode', $dir);
 
         return $this;
     }


### PR DESCRIPTION
Hey,

WDYT about something like this? @freekmurze 

Currently, this code will fail if you run only `gather` without `audit` since `gather` returns an empty response (therefore the change in the `lighthouse.js` file).

According to the docs:

https://github.com/GoogleChrome/lighthouse#lifecycle-examples

> --gather-mode, -G              Collect artifacts from a connected browser and save to disk. (Artifacts folder path may optionally be provided). **_If audit-mode is not also enabled, the run will quit early_**.

If you think this feature is useful, we can discuss how to fix the above issue.

Maybe we can do something like:
```PHP
$result1 = Lighthouse::url('https://example.com')
            ->saveArtifacts(__DIR__ . '/artifacts') // under the hood will use both audit-mode & gather-mode
            ->run( ... );
            ->audit( ... );

$result2 = Lighthouse::artifacts(__DIR__ . '/artifacts')
            ->run( ... );
            ->audit( ... );
```