### PR TITLE
Add array key to detect Lighthouse runtime errors

### DIFF
--- a/src/Lighthouse.php
+++ b/src/Lighthouse.php
@@ -220,10 +220,10 @@ class Lighthouse
             throw CouldNotRunLighthouse::make($process->getErrorOutput());
         }
 
-        if (array_key_exists('runtimeError', $result)) {
+        if (array_key_exists('runtimeError', $result['lhr'])) {
             throw LighthouseReportedError::make(
-                $result['runtimeError']['message'],
-                $result['runtimeError']['code'],
+                $result['lhr']['runtimeError']['message'],
+                $result['lhr']['runtimeError']['code'],
             );
         }
 


### PR DESCRIPTION
The `runtimeError` key on the `$result` array is keyed inside `lhr`.  This PR adds this key in order to throw the `LighthouseReportedError` exception, it would always be `false`otherwise.