### PR TITLE
Updated to support desktop view by default

### DIFF
--- a/src/Lighthouse.php
+++ b/src/Lighthouse.php
@@ -47,11 +47,14 @@ class Lighthouse
             'extends' => 'lighthouse:default',
             'settings' => [
                 'onlyCategories' => Category::values(),
-                'emulatedFormFactor' => 'desktop',
+                'formFactor' => 'desktop',
                 'output' => ['json', 'html'],
                 'disableNetworkThrottling' => true,
                 'disableCpuThrottling' => true,
                 'throttlingMethod' => 'provided',
+                'screenEmulation' => [
+                    'disabled' => true,
+                ]
             ],
         ];
     }
@@ -134,7 +137,17 @@ class Lighthouse
             $formFactor = FormFactor::fromString($formFactor);
         }
 
-        Arr::set($this->lighthouseConfig, 'settings.emulatedFormFactor', $formFactor->value);
+        Arr::set($this->lighthouseConfig, 'settings.formFactor', $formFactor->value);
+
+        return $this;
+    }
+
+    public function screenEmulation(?bool $mobile = false, ?bool $disabled = false, int $width = null, int $height = null, int $deviceScaleRatio = null): self
+    {
+        $screenEmulation = array_filter(compact('mobile', 'disabled', 'width', 'height', 'deviceScaleRatio'), function ($value) {
+            return $value !== null;
+        });
+        Arr::set($this->lighthouseConfig, 'settings.screenEmulation', $screenEmulation);
 
         return $this;
     }

--- a/src/LighthouseResult.php
+++ b/src/LighthouseResult.php
@@ -44,7 +44,7 @@ class LighthouseResult
 
     public function formFactor(): FormFactor
     {
-        return FormFactor::from($this->configSettings('emulatedFormFactor'));
+        return FormFactor::from($this->configSettings('formFactor'));
     }
 
     public function userAgent(): string

--- a/tests/LighthouseTest.php
+++ b/tests/LighthouseTest.php
@@ -93,8 +93,16 @@ it('will thrown a dedicated exception when lighthouse cannot run', function () {
 it('can set a form factor', function () {
     $this->lighthouse->formFactor(FormFactor::Mobile);
 
-    expect($this->lighthouse->lighthouseScriptArguments('lighthouseConfig.settings.emulatedFormFactor'))
+    expect($this->lighthouse->lighthouseScriptArguments('lighthouseConfig.settings.formFactor'))
         ->toEqual(FormFactor::Mobile->value);
+});
+
+it('can set a screen emulation', function () {
+    $screenEmulation = ['disabled' => true];
+    $this->lighthouse->screenEmulation($screenEmulation);
+
+    expect($this->lighthouse->lighthouseScriptArguments('lighthouseConfig.settings.screenEmulation'))
+        ->toEqual($screenEmulation);
 });
 
 it('can throttle cpu', function () {


### PR DESCRIPTION
I noticed an issue where all reports were emulated via mobile regardless of  `formFactor`

I noticed the docs for Lighthouse have been updated to rename `emulatedFormFactor` to `formFactor` and to add a `screenEmulation` property which also affected it, referenced [here](https://github.com/GoogleChrome/lighthouse/blob/main/docs/emulation.md).

I've made changes that allow editing of this and included a test for this, however, a lot of the tests were failing locally for me (prior to my changes), so may need further changes before ready for merging.