### PR TITLE
Implement an optional maxWaitForLoad() to avoid waiting too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Lighthouse::url('https://example.com')
     ->headers(['MyExtraHeader' => 'HeaderValue'])
     ->categories(Category::Performance, Category::Accessibility)
     ->throttleCpu()
+    ->maxWaitForLoad(5000) // Wait max 5 seconds for page load
     ->run();
 ```
 

--- a/bin/lighthouse.js
+++ b/bin/lighthouse.js
@@ -12,6 +12,11 @@
 
     const lighthouseConfig = arguments[2];
     const timeoutInMs = arguments[3];
+    const maxWaitForLoad = arguments[4];
+
+    if (maxWaitForLoad !== null && maxWaitForLoad !== undefined) {
+        lighthouseOptions.maxWaitForLoad = maxWaitForLoad;
+    }
 
     const killTimer = setTimeout(() => chrome.kill(), timeoutInMs);
 

--- a/src/Lighthouse.php
+++ b/src/Lighthouse.php
@@ -21,6 +21,8 @@ class Lighthouse
 
     protected int $timeoutInSeconds = 60;
 
+    protected ?int $maxWaitForLoadInMs = null;
+
     protected ?array $onlyAudits = null;
 
     public static function url(string $url): self
@@ -206,6 +208,13 @@ class Lighthouse
         return $this;
     }
 
+    public function maxWaitForLoad(int $maxWaitInMs): self
+    {
+        $this->maxWaitForLoadInMs = $maxWaitInMs;
+
+        return $this;
+    }
+
     public function run(): LighthouseResult
     {
         $arguments = $this->lighthouseScriptArguments();
@@ -252,6 +261,7 @@ class Lighthouse
             'chromeOptions' => $this->chromeOptions,
             'lighthouseConfig' => $this->lighthouseConfig,
             'timeout' => ($this->timeoutInSeconds * 1000) - 700,
+            'maxWaitForLoad' => $this->maxWaitForLoadInMs,
         ], $key);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -21,3 +21,18 @@ it('will throw an exception when the process times out', function () {
         ->timeoutInSeconds(1)
         ->run();
 })->throws(ProcessTimedOutException::class);
+
+it('can set maxWaitForLoad and complete within expected time', function () {
+    $startTime = microtime(true);
+
+    $result = Lighthouse::url('https://example.com')
+        ->maxWaitForLoad(1000) // 1 second max wait for load
+        ->timeoutInSeconds(15) // Overall timeout higher than maxWaitForLoad
+        ->run();
+
+    $endTime = microtime(true);
+    $executionTime = $endTime - $startTime;
+
+    expect($result->scores())->toBeArray();
+    expect($executionTime)->toBeLessThan(15);
+});

--- a/tests/LighthouseTest.php
+++ b/tests/LighthouseTest.php
@@ -213,3 +213,23 @@ it('can accept budgets', function () {
 
     expect($this->lighthouse->lighthouseScriptArguments('lighthouseConfig.settings.budgets'))->toEqual($budgets);
 });
+
+
+it('passes maxWaitForLoad to lighthouse script arguments', function () {
+    $lighthouse = Lighthouse::url('https://example.com')
+        ->maxWaitForLoad(5000);
+
+    $arguments = $lighthouse->lighthouseScriptArguments();
+
+    expect($arguments)->toHaveKey('maxWaitForLoad');
+    expect($arguments['maxWaitForLoad'])->toBe(5000);
+});
+
+it('does not include maxWaitForLoad when not set', function () {
+    $lighthouse = Lighthouse::url('https://example.com');
+
+    $arguments = $lighthouse->lighthouseScriptArguments();
+
+    expect($arguments)->toHaveKey('maxWaitForLoad');
+    expect($arguments['maxWaitForLoad'])->toBeNull();
+});


### PR DESCRIPTION
This optional parameter is useful for pages that have persistent connections or long-running requests (think: Cloudflare Challenges) to consider the page "loaded" and continue the analysis after this timeout